### PR TITLE
Audio type iframe sizing fix

### DIFF
--- a/src/core-package/iframe/handle-iframe.ts
+++ b/src/core-package/iframe/handle-iframe.ts
@@ -6,7 +6,12 @@ import {
     clampDimensions,
     scaleToConstraints,
 } from '../augments/dimensions';
-import {ImageType, ResizableImageData, isImageTypeTextLike} from '../image-data';
+import {
+    ImageType,
+    ResizableImageData,
+    isImageTypeAudioLike,
+    isImageTypeTextLike,
+} from '../image-data';
 import {MutatedClassesEnum} from '../vir-resizable-image/mutated-classes';
 import {MessageType, iframeMessenger} from './iframe-messenger';
 
@@ -137,9 +142,10 @@ export async function handleLoadedImageSize({
         box: forcedFinalImageSize ?? imageDimensions,
     } as const;
 
-    const newImageSize: Dimensions = isImageTypeTextLike(imageData.imageType)
-        ? clampDimensions(scalingInputs)
-        : scaleToConstraints(scalingInputs);
+    const newImageSize: Dimensions =
+        isImageTypeTextLike(imageData.imageType) || isImageTypeAudioLike(imageData.imageType)
+            ? clampDimensions(scalingInputs)
+            : scaleToConstraints(scalingInputs);
 
     frameConstraintDiv.style.width = addPx(Math.floor(newImageSize.width));
     frameConstraintDiv.style.height = addPx(Math.floor(newImageSize.height));

--- a/src/core-package/image-data.ts
+++ b/src/core-package/image-data.ts
@@ -25,8 +25,16 @@ const textLikeImageTypes: ReadonlyArray<ImageType> = [
     ImageType.Json,
 ];
 
+const audioLikeImageTypes: ReadonlyArray<ImageType> = [
+    ImageType.Audio,
+];
+
 export function isImageTypeTextLike(imageType: ImageType): boolean {
     return textLikeImageTypes.includes(imageType);
+}
+
+export function isImageTypeAudioLike(imageType: ImageType): boolean {
+    return audioLikeImageTypes.includes(imageType);
 }
 
 async function determineImageType(contentType: string, imageText: string): Promise<ImageType> {


### PR DESCRIPTION
# ClickUp task link

<!-- fill in task link below -->

https://app.clickup.com/t/863gaw8rd

# Changes

<!-- list the code changes made -->

- Added `audioLikeImageTypes` and `isImageTypeAudioLike`

# Key points to review

<!-- list any points that reviewers should especially scrutinize -->

- Audio type `newImageSize` returns `clampDimensions`