### PR TITLE
Added allow text scrolling

### DIFF
--- a/src/core-package/iframe/resizable-image-frame.ts
+++ b/src/core-package/iframe/resizable-image-frame.ts
@@ -11,6 +11,7 @@ export function generateIframeDoc(
     imageData: ResizableImageData,
     extraHtml: string | TemplateResult | undefined,
     htmlSizeQuerySelector: string | undefined,
+    allowScrolling: boolean | undefined,
 ): string {
     const placeholder = Math.random();
 
@@ -329,9 +330,18 @@ export function generateIframeDoc(
                                     (message.data.height - 2 * ${textPadding.y}) / oneLine,
                                 );
                                 const totalHeight = oneLine * totalLines;
+                                const scroll = ${allowScrolling ?? true};
                                 const textElement = document.querySelector('.text');
-                                textElement.style.height = totalHeight + 'px';
-                                textElement.style.setProperty('-webkit-line-clamp', totalLines);
+
+                                if (scroll) {
+                                    const textWrapperElement =
+                                        document.querySelector('.text-wrapper');
+                                    textWrapperElement.style.height = message.data.height + 'px';
+                                    textWrapperElement.style.setProperty('overflow-y', 'auto');
+                                } else {
+                                    textElement.style.height = totalHeight + 'px';
+                                    textElement.style.setProperty('-webkit-line-clamp', totalLines);
+                                }
                             }
 
                             document.documentElement.style.setProperty(

--- a/src/core-package/iframe/resizable-image-frame.ts
+++ b/src/core-package/iframe/resizable-image-frame.ts
@@ -11,7 +11,7 @@ export function generateIframeDoc(
     imageData: ResizableImageData,
     extraHtml: string | TemplateResult | undefined,
     htmlSizeQuerySelector: string | undefined,
-    allowScrolling: boolean | undefined,
+    allowTextScrolling: boolean | undefined,
 ): string {
     const placeholder = Math.random();
 
@@ -330,7 +330,7 @@ export function generateIframeDoc(
                                     (message.data.height - 2 * ${textPadding.y}) / oneLine,
                                 );
                                 const totalHeight = oneLine * totalLines;
-                                const scroll = ${allowScrolling ?? true};
+                                const scroll = ${allowTextScrolling ?? true};
                                 const textElement = document.querySelector('.text');
 
                                 if (scroll) {

--- a/src/core-package/vir-resizable-image/vir-resizable-image-inputs.ts
+++ b/src/core-package/vir-resizable-image/vir-resizable-image-inputs.ts
@@ -30,8 +30,8 @@ export type VirResizableImageInputs = {
     blockAutoPlay?: boolean | undefined;
     /** Block interaction with images, even on HTML pages. */
     blockInteraction?: boolean | undefined;
-    /** Set to true to allow scrolling of scrollable image types. */
-    allowScrolling?: boolean | undefined;
+    /** Set to true to allow text scrolling of text-like image types. */
+    allowTextScrolling?: boolean | undefined;
     /** Set to true to disable lazy loading. */
     eagerLoading?: boolean | undefined;
     /**

--- a/src/core-package/vir-resizable-image/vir-resizable-image-inputs.ts
+++ b/src/core-package/vir-resizable-image/vir-resizable-image-inputs.ts
@@ -30,6 +30,8 @@ export type VirResizableImageInputs = {
     blockAutoPlay?: boolean | undefined;
     /** Block interaction with images, even on HTML pages. */
     blockInteraction?: boolean | undefined;
+    /** Set to true to allow scrolling of scrollable image types. */
+    allowScrolling?: boolean | undefined;
     /** Set to true to disable lazy loading. */
     eagerLoading?: boolean | undefined;
     /**

--- a/src/core-package/vir-resizable-image/vir-resizable-image.element.ts
+++ b/src/core-package/vir-resizable-image/vir-resizable-image.element.ts
@@ -31,6 +31,11 @@ const imageTypesThatAllowInteraction: ReadonlyArray<ImageType> = [
     ImageType.Pdf,
 ] as const;
 
+const imageTypesThatAllowScrolling: ReadonlyArray<ImageType> = [
+    ImageType.Text,
+    ImageType.Json,
+] as const;
+
 export const VirResizableImage = defineElement<VirResizableImageInputs>()({
     tagName: resizableImageElementTagName,
     stateInitStatic: defaultResizableImageState,
@@ -284,6 +289,7 @@ export const VirResizableImage = defineElement<VirResizableImageInputs>()({
                                 resolvedImageData,
                                 inputs.extraHtml,
                                 inputs.htmlSizeQuerySelector,
+                                inputs.allowScrolling,
                             )}
                             ${onDomCreated(async (element) => {
                                 try {
@@ -343,7 +349,9 @@ export const VirResizableImage = defineElement<VirResizableImageInputs>()({
                     inputs.blockInteraction === false ||
                     /** Default behavior is to allow interaction based on the image type. */
                     (inputs.blockInteraction == undefined &&
-                        imageTypesThatAllowInteraction.includes(resolvedImageData.imageType));
+                        imageTypesThatAllowInteraction.includes(resolvedImageData.imageType)) ||
+                    (inputs.allowScrolling &&
+                        imageTypesThatAllowScrolling.includes(resolvedImageData.imageType));
 
                 if (isInteractionAllowed) {
                     return '';

--- a/src/core-package/vir-resizable-image/vir-resizable-image.element.ts
+++ b/src/core-package/vir-resizable-image/vir-resizable-image.element.ts
@@ -289,7 +289,7 @@ export const VirResizableImage = defineElement<VirResizableImageInputs>()({
                                 resolvedImageData,
                                 inputs.extraHtml,
                                 inputs.htmlSizeQuerySelector,
-                                inputs.allowScrolling,
+                                inputs.allowTextScrolling,
                             )}
                             ${onDomCreated(async (element) => {
                                 try {
@@ -350,7 +350,7 @@ export const VirResizableImage = defineElement<VirResizableImageInputs>()({
                     /** Default behavior is to allow interaction based on the image type. */
                     (inputs.blockInteraction == undefined &&
                         imageTypesThatAllowInteraction.includes(resolvedImageData.imageType)) ||
-                    (inputs.allowScrolling &&
+                    (inputs.allowTextScrolling &&
                         imageTypesThatAllowScrolling.includes(resolvedImageData.imageType));
 
                 if (isInteractionAllowed) {

--- a/src/example-app/ui/elements/vir-example-app.element.ts
+++ b/src/example-app/ui/elements/vir-example-app.element.ts
@@ -28,6 +28,7 @@ export const VirExampleApp = defineVirElementNoInputs({
             promise: Promise<void> | undefined;
             lastSearch: Record<string, string> | undefined;
         },
+        allowTextScrolling: false,
     },
     hostClasses: {
         'vir-example-app-show-constraints': ({state}) => state.showConstraints,
@@ -258,6 +259,21 @@ export const VirExampleApp = defineVirElementNoInputs({
                 </label>
             </p>
             <p>
+                <label class="inline-label">
+                    <input
+                        type="checkbox"
+                        ?checked=${state.allowTextScrolling}
+                        ${listen('input', (event) => {
+                            const checkbox = event.currentTarget as HTMLInputElement;
+                            updateState({
+                                allowTextScrolling: !!checkbox.checked,
+                            });
+                        })}
+                    />
+                    Allow text scrolling
+                </label>
+            </p>
+            <p>
                 ${(
                     [
                         'min',
@@ -304,7 +320,9 @@ export const VirExampleApp = defineVirElementNoInputs({
                     `;
                 })}
             </p>
-            <div class="images-container">${renderImages(ensuredConstraints, state.imageUrls)}</div>
+            <div class="images-container">
+                ${renderImages(ensuredConstraints, state.imageUrls, state.allowTextScrolling)}
+            </div>
         `;
     },
 });
@@ -312,6 +330,7 @@ export const VirExampleApp = defineVirElementNoInputs({
 function renderImages(
     constraints: DimensionConstraints,
     imageUrls: AsyncProp<ReadonlyArray<string>>,
+    allowTextScrolling: boolean | undefined,
 ) {
     return renderAsync(imageUrls, 'Loading...', (resolvedImageUrls) => {
         return sanitizeUrls(resolvedImageUrls).map((imageUrl) => {
@@ -331,6 +350,7 @@ function renderImages(
                                 imageUrl,
                                 max: constraints.max,
                                 min: constraints.min,
+                                allowTextScrolling,
                             })}
                         ></${VirResizableImage}>
                     </a>


### PR DESCRIPTION
# ClickUp task link

<!-- fill in task link below -->

https://app.clickup.com/t/865cedf89

# Changes

<!-- list the code changes made -->

- Added `allowTextScrolling` parameter for scrolling text-like image

# Key points to review

<!-- list any points that reviewers should especially scrutinize -->

- Added `height` and `overflow-y` for `.text-wrapper` if `allowTextScrolling` is `true`

# Screenshots and/or videos

<!-- attach screenshots or videos of changes made to the UI -->
<!-- if there is not anything to take screenshots of, delete this section -->


https://github.com/electrovir/resizable-image-element/assets/99699764/63dd9dfa-6e11-463a-81c0-b2256ca24a0e

## Quick test via local:
Check 'Allow text scrolling'

http://localhost:5174/?minW=608&minH=304&maxW=608&maxH=1216&imageUrls=https%3A%2F%2Fimages.bioniq.io%2Fbitcoin%2F4e0ad05cbbe3cfdbedec9edb37683a8284bc60ec4ced62272703f182d67e5d70i0
